### PR TITLE
[TASK] Loosen up magento-composer-install dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
         }
     ],
     "require": {
-        "magento-hackathon/magento-composer-installer": "2.*"
+        "magento-hackathon/magento-composer-installer": "*"
     }
 }


### PR DESCRIPTION
Can't update magento-hackathon/magento-composer-installer to 3.* because of the (old) dependency.